### PR TITLE
Add Nightly Docker Build

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -1,0 +1,24 @@
+name: Docker Image CI
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Docker Build & Push to Docker Hub
+      uses: opspresso/action-docker@master
+      with:
+        args: --docker
+      env:
+        USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKERFILE: "alpine/Dockerfile"
+        BUILD_PATH: "alpine/"
+        IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/synclounge
+        TAG_NAME: "nightly"
+        LATEST: "true"


### PR DESCRIPTION
Just thought I'd throw a pr together for this. 

I added an automated nightly build to the repo that'll push to docker hub if you set the `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets in the repo settings.

Understand if you're not interested in a nightly build, feel free to say so and close :) 